### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
 jobs:
   lint:
     docker:
-      - image: python:3-buster
+      - image: python:3.9-buster
         auth: &docker-hub-auth
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -71,7 +71,7 @@ jobs:
 
   test-by-examples:
     docker:
-      - image: python:3-buster
+      - image: python:3.9-buster
         auth: &docker-hub-auth
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -97,7 +97,7 @@ jobs:
       package-name:
         type: string
     docker:
-      - image: python:3-buster
+      - image: python:3.9-buster
         auth: *docker-hub-auth
     steps:
       - checkout
@@ -115,7 +115,7 @@ jobs:
 
   deploy-onnion:
     docker:
-      - image: python:3-buster
+      - image: python:3.9-buster
         auth: *docker-hub-auth
     steps:
       - checkout
@@ -129,7 +129,7 @@ jobs:
 
   deploy-onnion-rt:
     docker:
-      - image: python:3-buster
+      - image: python:3.9-buster
         auth: *docker-hub-auth
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ commands:
       - run:
           name: install poetry
           command: |
-            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-            echo 'export PATH=$HOME/.poetry/bin:$PATH' >> $BASH_ENV
+            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
             poetry config virtualenvs.in-project true
       - run:


### PR DESCRIPTION
Some libraries do not support Python 3.10 yet.
So, use python:3.9-buster for a while.