### PR TITLE
Bump onnion-rt 0.5.0

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Idein/onnion/tree/master/compiler"
 python = "^3.7"
 onnx = "^1.9.0"
 numpy = "^1.21.0"
-onnion-rt = "^0.4.0"
+onnion-rt = ">=0.4.0"
 
 [tool.poetry.dev-dependencies]
 pysen = {version = "^0.10.1"}

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onnion-rt"
-version = "0.4.0"
+version = "0.5.0"
 description = "run onnx with only numpy"
 authors = ["Idein Inc."]
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-numpy = "^1.19.0"
+numpy = "^1.19.0, != 1.21.5"
 
 [tool.poetry.dev-dependencies]
 pysen = {version = "^0.10.1"}


### PR DESCRIPTION
- Support more operators
- Avoid numpy == 1.21.5