### PR TITLE
fixes "supported operators" branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - compile onnx to python
 - runtime depends only numpy
 
-See [supported operators](https://github.com/Idein/onnion/tree/main/runtime#supported-operators).
+See [supported operators](https://github.com/Idein/onnion/tree/master/runtime#supported-operators).
 
 ## Tutorial
 Extract the post-process of [Ultraface](https://github.com/onnx/models/tree/main/vision/body_analysis/ultraface) and run it.


### PR DESCRIPTION
The default branch name is still "master", so the `supported operators` reference URL is `main`, which causes broken links.

If you plan to switch the branch name to "main" in the near future, ignore it.