### PR TITLE
Acceleration convtranspose

### DIFF
--- a/runtime/onnion_runtime/convtranspose.py
+++ b/runtime/onnion_runtime/convtranspose.py
@@ -97,6 +97,6 @@ class ConvTranspose:
                     ow_max = min(strides[1] * iw + kernel_shape[1] * dilations[1] - pads[1],
                                  output_shape[1])
                     v = np.sum(x[n, :, ih, iw].reshape(-1, 1, 1, 1) * W, axis=0)
-                    result[n, :, oh_min:oh_max, ow_min:ow_max] += v
+                    result[n, :, oh_min:oh_max:dilations[0], ow_min:ow_max:dilations[1]] += v
 
         return [result]

--- a/runtime/onnion_runtime/convtranspose.py
+++ b/runtime/onnion_runtime/convtranspose.py
@@ -42,7 +42,6 @@ class ConvTranspose:
         dim = len(x.shape) - 2
         group = self.group
         batch = x.shape[0]
-        in_ch = x.shape[1]
         out_ch = W.shape[1]
         dilations = self.dilations or [1] * dim
         strides = self.strides or [1] * dim
@@ -86,17 +85,15 @@ class ConvTranspose:
         result = np.zeros([batch, out_ch, *output_shape], dtype=x.dtype)
         for och in range(out_ch):
             if b is not None:
-                result[n, och, :, :] += b[och]
+                result[:, och, :, :] += b[och]
         for n in range(batch):
             for ih in range(input_shape[0]):
                 for iw in range(input_shape[1]):
                     oh_min = max(strides[0] * ih - pads[0], 0)
-                    oh_max = min(strides[0] * ih + kernel_shape[0] * dilations[0] - pads[0],
-                                 output_shape[0])
+                    oh_max = min(strides[0] * ih + kernel_shape[0] * dilations[0] - pads[0], output_shape[0])
                     ow_min = max(strides[1] * iw - pads[1], 0)
-                    ow_max = min(strides[1] * iw + kernel_shape[1] * dilations[1] - pads[1],
-                                 output_shape[1])
+                    ow_max = min(strides[1] * iw + kernel_shape[1] * dilations[1] - pads[1], output_shape[1])
                     v = np.sum(x[n, :, ih, iw].reshape(-1, 1, 1, 1) * W, axis=0)
-                    result[n, :, oh_min:oh_max:dilations[0], ow_min:ow_max:dilations[1]] += v
+                    result[n, :, oh_min : oh_max : dilations[0], ow_min : ow_max : dilations[1]] += v
 
         return [result]


### PR DESCRIPTION
convtranspose層の実装をループを排除して高速化しました。

以下のonnx, コード, onnionコンパイル後スクリプトでtestしました。

[test.zip](https://github.com/Idein/onnion/files/12190363/test.zip)

テスト環境：
CPU : Intel(R) Core(TM) i5-12400F
MEM : 16GB

修正前結果：
```
$ python3 test.py
/usr/local/lib/python3.10/dist-packages/onnion_runtime/sigmoid.py:10: RuntimeWarning: overflow encountered in exp
  return [1.0 / (1.0 + np.exp(np.negative(x)))]
onnion_time:32.9430296421051sec
ort_time:0.013541698455810547sec
maximum relative error: 4.1127e-06
```

修正後結果：
```
$ python3 test.py
/usr/local/lib/python3.10/dist-packages/onnion_runtime/sigmoid.py:10: RuntimeWarning: overflow encountered in exp
  return [1.0 / (1.0 + np.exp(np.negative(x)))]
onnion_time:1.5471618175506592sec
ort_time:0.013427495956420898sec
maximum relative error: 4.1723e-06
```