### PR TITLE
Remove version from setup_remote_docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,8 +155,7 @@ jobs:
           name: Build docker image
           command: |
             nix --experimental-features 'nix-command flakes' build '.#dockerimage' -o image -L
-      - setup_remote_docker:
-          version: 20.10.7
+      - setup_remote_docker
       - run:
           name: Install docker client
           command: |


### PR DESCRIPTION
circleciで利用できないversionを指定しているので削除する